### PR TITLE
spaces in file trigger jshint errors

### DIFF
--- a/templates/javascript/directive.js
+++ b/templates/javascript/directive.js
@@ -2,13 +2,13 @@ define(['angular'], function (angular) {
   'use strict';
 
   angular.module('<%= scriptAppName %>.directives.<%= classedName %>', [])
-  	.directive('<%= cameledName %>', function () {
+    .directive('<%= cameledName %>', function () {
       return {
-      	template: '<div></div>',
-      	restrict: 'E',
-      	link: function postLink(scope, element, attrs) {
+        template: '<div></div>',
+        restrict: 'E',
+        link: function postLink(scope, element, attrs) {
           element.text('this is the <%= cameledName %> directive');
-      	}
+        }
       };
-  	});
+    });
 });


### PR DESCRIPTION
Changed the spaces to tabs.

There is also this error:

```
Gruntfile.js
  line 379  col 45  Strings must use singlequote.
```

but that line in templates/common/Gruntfile.js doesn't have double-quotes.
