### PR TITLE
fix bower dependencies paths lookup

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
     <!-- build:css(.) styles/vendor.css -->
+    <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
     <!-- bower:css -->
     <!-- endbower -->
     <!-- endbuild -->

--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -474,6 +474,7 @@ module.exports = function (grunt) {
     grunt.task.run([
       'clean:server',
       'wiredep',
+      'bower:app',
       'concurrent:server',
       'autoprefixer:server',
       'connect:livereload',


### PR DESCRIPTION
## Problem
Talked about on issue #59 when `grunt serve` is triggered all require deps are looked for on "http://localhost:9000/scripts/" folder instead of on "\bower_components" folder because `main.js` file doesn't have components paths for requirejs to look for them so it tries to find them on current directory (scripts)

```js
require.config({
  paths: {},
  shim: {
[...]
```

## Solution
Grunt `serve` task is not using `bower:app` among his dependencies so this require.js paths configuration is not being populated, although `build` task has it

At the same time `bootstrap.css` is not being included in "<!-- build:css(.) styles/vendor.css -->" in index.html so it doesn't get included not on `serve` task nor on `build` task