### PR TITLE
bower task from grunt-bower-requirejs is deprecated

### DIFF
--- a/templates/common/root/README.md
+++ b/templates/common/root/README.md
@@ -3,9 +3,13 @@
 This project is generated with [yo angular-require generator](https://github.com/aaronallport/generator-angular-require)
 version <%= pkg.version %>.
 
-## Build & development
+## Development & building
 
-Run `grunt` for building and `grunt serve` for preview.
+Run `grunt serve` for development preview.
+
+Run `grunt` for building.
+
+Run `grunt serve:dist` for building and previewing.
 
 ## Testing
 

--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -422,7 +422,7 @@ module.exports = function (grunt) {
     },
 
     // Settings for grunt-bower-requirejs
-    bower: {
+    bowerRequirejs: {
       app: {
         rjsConfig: '<%%= yeoman.app %>/scripts/main.js',
         options: {
@@ -474,7 +474,7 @@ module.exports = function (grunt) {
     grunt.task.run([
       'clean:server',
       'wiredep',
-      'bower:app',
+      'bowerRequirejs:app',
       'concurrent:server',
       'autoprefixer:server',
       'connect:livereload',
@@ -489,7 +489,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test', [
     'clean:server',
-    'bower:app',
+    'bowerRequirejs:app',
     'replace:test',
     'wiredep',
     'concurrent:test',
@@ -501,7 +501,7 @@ module.exports = function (grunt) {
   grunt.registerTask('build', [
     'clean:dist',
     'wiredep',
-    'bower:app',
+    'bowerRequirejs:app',
     'replace:test',
     'useminPrepare',
     'concurrent:dist',


### PR DESCRIPTION
Updated reference of grunt-bower-requirejs due to deprecation, from `bower` to `bowerRequirejs`